### PR TITLE
Added dependency on api-client-1.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^7.2",
-        "itk-dev/pretix-api-client-php": "dev-develop",
+        "itk-dev/pretix-api-client-php": "^1.0",
         "nicoeg/dawa": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
itk-dev/pretix-api-client-php has been tagged with 1.0.0.
We now need to require that version